### PR TITLE
Fixes type of the onStatusChange callback in types/index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -144,7 +144,7 @@ export interface RNCameraProps {
 
   onCameraReady?(): void;
   onStatusChange?(event: {
-    cameraStatus: CameraStatus;
+    cameraStatus: keyof CameraStatus;
     recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
   }): void;
   onMountError?(error: { message: string }): void;


### PR DESCRIPTION
Currently, the `onStatusChange` has a type of 
```ts
onStatusChange?(event: {
    cameraStatus: CameraStatus;
    recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
  }): void
```
Which makes it very inconvenient to use with Typescript, having to set the `cameraStatus` field to `any` in the passed function:
```ts
const handleStatusChange = (event: {cameraStatus: any}) => {
    if (event.cameraStatus === 'NOT_AUTHORIZED') {
      // important code
    }
  }
```
By changing it to
```diff ts
onStatusChange?(event: {
-    cameraStatus: CameraStatus;
+    cameraStatus: keyof CameraStatus;
    recordAudioPermissionStatus: keyof RecordAudioPermissionStatus;
  }): void
```
we're able to compare the new status against the intended type, autocomplete, and discard the `any`:
```ts

  const handleStatusChange = (event: {cameraStatus: keyof CameraStatus}) => {
    if (event.cameraStatus === 'NOT_AUTHORIZED') {
      // important code
    }
  }
```